### PR TITLE
remove full stops and quotation marks on holding comment free text op…

### DIFF
--- a/server/public/static/js/partials/addFeature.js
+++ b/server/public/static/js/partials/addFeature.js
@@ -112,15 +112,15 @@ window.LTFMGMT.addFeatureHtml = function (featureIndex, type) {
                   <label class="control-label" for="features_${featureIndex}_properties_info">Enter the holding comment text</label>
                   <div id="features_${featureIndex}_properties_info__description" class="field-description">
                     <p>For example:</p>
-                    <p>For updates to when NaFRA2 data will be available: "Some of the rivers and sea flood risk data for this location is 
-                      currently unavailable. We'll publish this data by [month]."</p>
-                    <p>For other scenarios (new modelling): "We will update this data to include new rivers and sea information for this area. 
-                      For information, email <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a>.”</p>
-                    <p>For flood alleviation schemes: "A flood management scheme in [Weston-Super-Mare] has been completed. We will include this 
+                    <p>For updates to when NaFRA2 data will be available: Some of the rivers and sea flood risk data for this location is 
+                      currently unavailable. We'll publish this data by [month]</p>
+                    <p>For other scenarios (new modelling): We will update this data to include new rivers and sea information for this area. 
+                      For information, email <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a></p>
+                    <p>For flood alleviation schemes: A flood management scheme in [Weston-Super-Mare] has been completed. We will include this 
                       in our rivers and sea data. For information, email 
-                      <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a>.”</p>
-                    <p>Data currently being reviewed: "We are reviewing rivers and sea data for this area. For information, contact 
-                      <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a>.”</p>
+                      <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a></p>
+                    <p>Data currently being reviewed: We are reviewing rivers and sea data for this area. For information, contact 
+                      <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a></p>
                     <p>The holding comment text will display to public users in this area. Read 
                       <a href="/comment-guidance" target="_blank" previewlistener="true">comment guidance</a>
                       before writing or pasting anything. The maximum number of characters is 180.</p>

--- a/server/views/comment-edit.html
+++ b/server/views/comment-edit.html
@@ -123,15 +123,15 @@
                                 for="features_{{ features.indexOf(feature) }}_properties_info">Enter the holding comment text</label>
                               <div id="features_{{ features.indexOf(feature) }}_properties_info__description" class="field-description">
                                 <p>For example:</p>
-                                <p>For updates to when NaFRA2 data will be available: "Some of the rivers and sea flood risk data for this location is 
-                                  currently unavailable. We'll publish this data by [month]."</p>
-                                <p>For other scenarios (new modelling): "We will update this data to include new rivers and sea information for this area. 
-                                  For information, email <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a>”</p>
-                                <p>For flood alleviation schemes: "A flood management scheme in [Weston-Super-Mare] has been completed. We will include this 
+                                <p>For updates to when NaFRA2 data will be available: Some of the rivers and sea flood risk data for this location is 
+                                  currently unavailable. We'll publish this data by [month]</p>
+                                <p>For other scenarios (new modelling): We will update this data to include new rivers and sea information for this area. 
+                                  For information, email <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a></p>
+                                <p>For flood alleviation schemes: A flood management scheme in [Weston-Super-Mare] has been completed. We will include this 
                                   in our rivers and sea data. For information, email 
-                                  <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a>”</p>
-                                <p>Data currently being reviewed: "We are reviewing rivers and sea data for this area. For information, contact 
-                                  <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a>”</p>
+                                  <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a></p>
+                                <p>Data currently being reviewed: We are reviewing rivers and sea data for this area. For information, contact 
+                                  <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a></p>
                                 <p>The holding comment text will display to public users in this area. Read 
                                   <a href="/comment-guidance" target="_blank" previewlistener="true">comment guidance</a>
                                   before writing or pasting anything. The maximum number of characters is 180.</p>


### PR DESCRIPTION
…tion

https://eaflood.atlassian.net/jira/software/c/projects/LTFRI/boards/589?selectedIssue=LTFRI-1768

This update removes full stops and quotation marks from examples so user include them when copying the text.